### PR TITLE
Non usb8 buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,12 @@ To play random noise on one channel of default stereo device:
 (defconstant +channels+ 2)
 
 (also-alsa:with-alsa-device (pcm "sysdefault" +buffer-size+ '(signed-byte 16) :direction :output
-				 :channels-count +channels+ :sample-rate +sample-rate+)
+                                                                              :channels-count +channels+ :sample-rate +sample-rate+)
   (also-alsa:alsa-start pcm)
-  (loop repeat 2 do
-       (loop with buffer = (also-alsa:buffer pcm)
-	  for pos from 0 below (* +channels+ (also-alsa:buffer-size pcm)) by (* 2 +channels+)
-	  for sample = (coerce (- (random 65535) 32767) '(signed-byte 16)) do
-	    (setf (aref buffer pos) (logand sample #xff))
-	    (setf (aref buffer (1+ pos)) (logand (ash sample -8) #xff))
-	    (multiple-value-bind (avail delay) (also-alsa:get-avail-delay pcm)
-	      (also-alsa:alsa-write pcm)))))
-
+  (loop with buffer = (also-alsa:buffer pcm)
+        for pos from 0 below (also-alsa:buffer-size pcm)
+        for sample = (coerce (- (random 65535) 32767) '(signed-byte 16)) do
+          (setf (aref buffer pos) sample)
+          (multiple-value-bind (avail delay) (also-alsa:get-avail-delay pcm)
+            (also-alsa:alsa-write pcm))))
 ```

--- a/also-alsa.lisp
+++ b/also-alsa.lisp
@@ -167,7 +167,7 @@
 
 (defun alsa-element-type (type)
   (cond ((equalp type '(signed-byte 16)) :int16)
-	((eql type 'single-float) :float)
+        ((eql type 'single-float) :float)
         ((eql type 'double-float) :double)
         ((equalp type '(unsigned-byte 8)) :uint8)
         ((equalp type '(signed-byte 8)) :int8)
@@ -215,7 +215,7 @@
 (defun alsa-open (device buffer-size element-type &key direction (sample-rate 44100) (channels-count 2) buffer)
   (when buffer
     (assert (and (subtypep (type-of buffer) 'simple-array)
-		 (subtypep (array-element-type buffer) element-type))))
+                 (subtypep (array-element-type buffer) element-type))))
   (let ((pcs (make-instance 'pcm-stream
 			    :direction (case direction
 					 (:input :snd-pcm-stream-capture)
@@ -223,7 +223,7 @@
 			    :device device
 			    :element-type element-type
 			    :buffer (or buffer
-					(make-alsa-buffer :element-type element-type :size buffer-size :channels channels-count))
+                            (make-alsa-buffer :element-type element-type :size buffer-size :channels channels-count))
 			    :buffer-size (* buffer-size channels-count) ;number of samples really
 			    :channels-count channels-count
 			    :sample-rate sample-rate
@@ -311,7 +311,7 @@
 		   (snd-pcm-writei (deref (handle pcm)) ptr expected))))
     (cond ((= result (- +epipe+))
            ;; Under run, so prepare and retry
-	   (alsa-warn "Underrun!")
+           (alsa-warn "Underrun!")
            (snd-pcm-prepare (deref (handle pcm)))
            (alsa-write pcm))
           ((/= result expected)
@@ -323,8 +323,8 @@
 		  (snd-pcm-readi (deref (handle pcm)) ptr (/ (buffer-size pcm) (channels-count pcm))))))
     (unless (= result (/ (buffer-size pcm) (channels-count pcm)))
       (if (eql result (- +epipe+))
-	  (progn (alsa-warn "Underrun!") (snd-pcm-prepare (deref (handle pcm))))
-	  (error "ALSA error: ~A" result)))
+          (progn (alsa-warn "Underrun!") (snd-pcm-prepare (deref (handle pcm))))
+          (error "ALSA error: ~A" result)))
     pcm))
 
 (defmethod contents-to-lisp ((pcm pcm-stream))


### PR DESCRIPTION
This enables support for non-unsigned-byte-8 buffers (single, double, unsigned-byte-16 etc) natively for buffers of `pcm-stream`. The cost for it is a nasty `cffi::unsure-parsed-type` hack, which is licely to work for more than a decade from now, though.

The reason for the change was that I wanted to play some float-based data with ALSA and realized I need to cast it to usb8, which is not exacly easy in Lisp. Thus, this pretty changeset that allows setting buffers to any valid ALSA-friendly type, including floats. 

I've tested it, and it seems to work, although the output is somewhat slow.

@varjagg, does this change make sense?